### PR TITLE
shards: Do not fatal if no indexes are present

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -137,6 +137,10 @@ func main() {
 		go divertLogs(*logDir, *logRefresh)
 	}
 
+	if err := os.MkdirAll(*index, 0755); err != nil {
+		log.Fatal(err)
+	}
+
 	searcher, err := shards.NewDirectorySearcher(*index)
 	if err != nil {
 		log.Fatal(err)

--- a/shards/watcher.go
+++ b/shards/watcher.go
@@ -93,10 +93,6 @@ func (s *shardWatcher) scan() error {
 		return err
 	}
 
-	if len(fs) == 0 {
-		return fmt.Errorf("directory %s is empty", s.dir)
-	}
-
 	ts := map[string]time.Time{}
 	for _, fn := range fs {
 		fi, err := os.Lstat(fn)


### PR DESCRIPTION
This is good behaviour for the `zoekt` command, but for the webserver we would
rather it waits until the first index is ready.

Part of https://github.com/sourcegraph/sourcegraph/issues/8610