### PR TITLE
DONOTMERGE eval: Do exact matching on repo clause

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -1,0 +1,52 @@
+package zoekt
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/zoekt/query"
+)
+
+// qgot prevents compiler optimizing away return value of simplifyRepo
+var qgot query.Q
+
+func BenchmarkSimplifyRepo(b *testing.B) {
+	q, err := query.Parse("test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	var reposQ []query.Q
+	for i := 0; i < 2018; i++ {
+		reposQ = append(reposQ, &query.Repo{Pattern: "github.com/foo/bar-" + strconv.Itoa(i)})
+	}
+	q = query.Simplify(query.NewAnd(q, query.NewOr(reposQ...)))
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		qgot = simplifyRepo(q, "github.com/foo/bar-100")
+	}
+}
+
+func TestSimplifyRepo(t *testing.T) {
+	q, err := query.Parse("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := q.String()
+	var reposQ []query.Q
+	for i := 0; i < 2018; i++ {
+		reposQ = append(reposQ, &query.Repo{Pattern: "github.com/foo/bar-" + strconv.Itoa(i)})
+	}
+	q = query.Simplify(query.NewAnd(q, query.NewOr(reposQ...)))
+
+	got := simplifyRepo(q, "github.com/foo/bar-100")
+	if got.String() != want {
+		t.Fatalf("got %v != %v", got.String(), want)
+	}
+
+	want = (&query.Const{Value: false}).String()
+	got = simplifyRepo(q, "github.com/foo/baz")
+	if got.String() != want {
+		t.Fatalf("got %v != %v", got.String(), want)
+	}
+}


### PR DESCRIPTION
We want this behaviour given the queries we build from Sourcegraph. Also added a
test and benchmark:

```
name            old time/op    new time/op    delta
SimplifyRepo-4     242µs ± 2%     230µs ± 2%  -5.16%  (p=0.000 n=10+9)

name            old alloc/op   new alloc/op   delta
SimplifyRepo-4     367kB ± 0%     367kB ± 0%    ~     (all equal)

name            old allocs/op  new allocs/op  delta
SimplifyRepo-4     2.07k ± 0%     2.07k ± 0%    ~     (all equal)
```

I'm not sure if this is the right way to go, but my next step is to optimize this query into one which notices the large `AND` and avoid allocating so much memory. A better approach may be to add a new type to query called `RepoList` and then inside of that we store a Map of repos. I'll try the optimizer and if that approach seems fruitful I'll not do the RepoList approach.