### PR TITLE
remove PerPage arg in sourcegraph repos list call

### DIFF
--- a/cmd/zoekt-mirror-sourcegraph/main.go
+++ b/cmd/zoekt-mirror-sourcegraph/main.go
@@ -62,7 +62,7 @@ func main() {
 
 func listRepos(root *url.URL) ([]string, error) {
 	u := root.ResolveReference(&url.URL{Path: "/.internal/repos/list"})
-	resp, err := http.Post(u.String(), "application/json; charset=utf8", bytes.NewReader([]byte(`{"PerPage": 10000, "Enabled": true}`)))
+	resp, err := http.Post(u.String(), "application/json; charset=utf8", bytes.NewReader([]byte(`{"Enabled": true}`)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- the PerPage arg was removed (it's now Limit)
- but also we need more than 10k anyway, so we should just remove this