### PR TITLE
sourcegraph: Create empty index for empty repositories

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -283,7 +283,8 @@ func (b *Builder) flush() error {
 		return b.buildError
 	}
 
-	if len(todo) == 0 {
+	hasShard := b.nextShardNum > 0
+	if len(todo) == 0 && hasShard {
 		return nil
 	}
 


### PR DESCRIPTION
Currently an empty repository will never show up in the list of indexed
repositories, since there is no content to index. This leads to sourcegraph
believing the repos have not been indexed which can report confusing behaviour
to users. We can index empty repositories, we just need to create empty
indexes.