### PR TITLE
sourcegraph: Trace indexing

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -22,12 +22,25 @@ import (
 	"github.com/google/zoekt/build"
 )
 
+// Server is the main functionality of zoekt-sourcegraph-indexserver. It
+// exists to conveniently use all the options passed in via func main.
 type Server struct {
-	Root     *url.URL
+	// Root is the base URL for the Sourcegraph instance to index. Normally
+	// http://sourcegraph-frontend-internal or http://localhost:3090.
+	Root *url.URL
+
+	// IndexDir is the index directory to use.
 	IndexDir string
+
+	// Interval is how often we sync with Sourcegraph.
 	Interval time.Duration
+
+	// CPUCount is the amount of parallelism to use when indexing a
+	// repository.
 	CPUCount int
-	Debug    bool
+
+	// Debug when true will output extra debug logs.
+	Debug bool
 }
 
 func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) {
@@ -54,6 +67,7 @@ func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) {
 	}
 }
 
+// Refresh is starts the sync loop. It blocks forever.
 func (s *Server) Refresh() {
 	t := time.NewTicker(s.Interval)
 	for {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -27,6 +27,7 @@ type Server struct {
 	IndexDir string
 	Interval time.Duration
 	CPUCount int
+	Debug    bool
 }
 
 func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) {
@@ -47,6 +48,9 @@ func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) {
 			cmd.Args, err, outS, errS)
 	} else {
 		tr.LazyPrintf("success")
+		if s.Debug {
+			log.Printf("ran successfully %s", cmd.Args)
+		}
 	}
 }
 
@@ -227,6 +231,8 @@ func main() {
 	listen := flag.String("listen", "", "listen on this address.")
 	cpuFraction := flag.Float64("cpu_fraction", 0.25,
 		"use this fraction of the cores for indexing.")
+	debug := flag.Bool("debug", false,
+		"turn on more verbose logging.")
 	flag.Parse()
 
 	if *cpuFraction <= 0.0 || *cpuFraction > 1.0 {
@@ -264,6 +270,7 @@ func main() {
 		IndexDir: *index,
 		Interval: *interval,
 		CPUCount: cpuCount,
+		Debug:    *debug,
 	}
 
 	if *listen != "" {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -64,6 +64,7 @@ func (s *Server) Refresh() {
 			continue
 		}
 
+		log.Printf("indexing %d repositories", len(repos))
 		for _, name := range repos {
 			s.index(name)
 		}


### PR DESCRIPTION
This is the start of adding more features to our indexserver. Initially we
expose the traces on each request. This should be a much nicer way to inspect
problems via port-forwarding the web interface. As we improve, we will likely
show more of this information in a nicer way in the main sourcegraph UI.