### PR TITLE
indexserver: Use a priority queue and API batching

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1,4 +1,5 @@
-// zoekt-sourcegraph-indexserver periodically reindexes enabled repositories on sourcegraph
+// Command zoekt-sourcegraph-indexserver periodically reindexes enabled
+// repositories on sourcegraph
 package main
 
 import (
@@ -15,7 +16,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"time"
 
 	"golang.org/x/net/trace"
@@ -43,12 +43,9 @@ type Server struct {
 
 	// Debug when true will output extra debug logs.
 	Debug bool
-
-	mu    sync.Mutex
-	repos []string
 }
 
-func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) {
+func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) error {
 	out := &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
 	cmd.Stdout = out
@@ -62,69 +59,109 @@ func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) {
 		tr.LazyPrintf("stdout: %s", outS)
 		tr.LazyPrintf("stderr: %s", errS)
 		tr.SetError()
-		log.Printf("command %s failed: %v\nOUT: %s\nERR: %s",
+		return fmt.Errorf("command %s failed: %v\nOUT: %s\nERR: %s",
 			cmd.Args, err, outS, errS)
-	} else {
-		tr.LazyPrintf("success")
-		if s.Debug {
-			log.Printf("ran successfully %s", cmd.Args)
-		}
 	}
+	tr.LazyPrintf("success")
+	if s.Debug {
+		log.Printf("ran successfully %s", cmd.Args)
+	}
+	return nil
 }
 
 // Refresh is starts the sync loop. It blocks forever.
 func (s *Server) Refresh() {
-	t := time.NewTicker(s.Interval)
-	for {
-		repos, err := listRepos(s.Root)
-		if err != nil {
-			log.Println(err)
+	queue := &Queue{}
+
+	// Start a goroutine which updates the queue with commits to index.
+	go func() {
+		t := time.NewTicker(s.Interval)
+		for {
+			repos, err := listRepos(s.Root)
+			if err != nil {
+				log.Println(err)
+				<-t.C
+				continue
+			}
+
+			log.Printf("updating index queue with %d repositories", len(repos))
+
+			// ResolveRevision is IO bound on the gitserver service. So we do
+			// them concurrently.
+			sem := newSemaphore(32)
+			tr := trace.New("resolveRevisions", "")
+			tr.LazyPrintf("resolving HEAD for %d repos", len(repos))
+			for _, name := range repos {
+				sem.Acquire()
+				go func(name string) {
+					defer sem.Release()
+					commit, err := resolveRevision(s.Root, name, "HEAD")
+					if err != nil && !os.IsNotExist(err) {
+						tr.LazyPrintf("failed resolving HEAD for %v: %v", name, err)
+						tr.SetError()
+						return
+					}
+					queue.AddOrUpdate(name, commit)
+				}(name)
+			}
+			sem.Wait()
+			tr.Finish()
+
 			<-t.C
+		}
+	}()
+
+	// Start a goroutine which deletes shards for repos which no longer exist
+	go func() {
+		t := time.NewTicker(s.Interval)
+		for {
+			repos, err := listRepos(s.Root)
+			if err != nil {
+				log.Println(err)
+				<-t.C
+				continue
+			}
+
+			if len(repos) > 0 {
+				// Only delete shards if we found repositories, to prevent strange
+				// bugs in responses causing us to delete everything.
+				exists := make(map[string]bool)
+				for _, name := range repos {
+					exists[name] = true
+				}
+				s.deleteStaleIndexes(exists)
+			}
+
+			<-t.C
+		}
+	}()
+
+	// In the current goroutine process the queue forever.
+	for {
+		name, commit, ok := queue.Pop()
+		if !ok {
+			time.Sleep(time.Second)
 			continue
 		}
 
-		// update repos for indexing interface
-		s.mu.Lock()
-		s.repos = repos
-		s.mu.Unlock()
-
-		start := time.Now()
-		log.Printf("indexing %d repositories", len(repos))
-		for _, name := range repos {
-			s.Index(name)
+		err := s.Index(name, commit)
+		if err != nil {
+			log.Printf("error indexing %s@%s: %s", name, commit, err)
+			continue
 		}
-		log.Printf("indexed %d repositories after %s", len(repos), time.Since(start))
-
-		if len(repos) > 0 {
-			// Only delete shards if we found repositories
-			exists := make(map[string]bool)
-			for _, name := range repos {
-				exists[name] = true
-			}
-			s.deleteStaleIndexes(exists)
-		}
-
-		<-t.C
+		queue.SetIndexed(name, commit)
 	}
 }
 
-func (s *Server) Index(name string) error {
+// Index starts an index job for repo name at commit.
+func (s *Server) Index(name, commit string) error {
 	tr := trace.New("index", name)
 	defer tr.Finish()
 
-	commit, err := resolveRevision(s.Root, name, "HEAD")
-	if err != nil || commit == "" {
-		if os.IsNotExist(err) {
-			// If we get to this point, it means we have an empty
-			// repository (ie we know it exists). As such, we just
-			// create an empty shard.
-			tr.LazyPrintf("empty repository")
-			s.createEmptyShard(tr, name)
-			return nil
-		}
-		log.Printf("failed to resolve revision HEAD for %v: %v", name, err)
-		tr.LazyPrintf("%v", err)
-		return err
+	tr.LazyPrintf("commit: %v", commit)
+
+	if commit == "" {
+		return s.createEmptyShard(tr, name)
 	}
 
 	cmd := exec.Command("zoekt-archive-index",
@@ -137,11 +174,10 @@ func (s *Server) Index(name string) error {
 		tarballURL(s.Root, name, commit))
 	// Prevent prompting
 	cmd.Stdin = &bytes.Buffer{}
-	s.loggedRun(tr, cmd)
-	return nil
+	return s.loggedRun(tr, cmd)
 }
 
-func (s *Server) createEmptyShard(tr trace.Trace, name string) {
+func (s *Server) createEmptyShard(tr trace.Trace, name string) error {
 	cmd := exec.Command("zoekt-archive-index",
 		"-index", s.IndexDir,
 		"-incremental",
@@ -152,7 +188,7 @@ func (s *Server) createEmptyShard(tr trace.Trace, name string) {
 		"-")
 	// Empty archive
 	cmd.Stdin = bytes.NewBuffer(bytes.Repeat([]byte{0}, 1024))
-	s.loggedRun(tr, cmd)
+	return s.loggedRun(tr, cmd)
 }
 
 func (s *Server) deleteStaleIndexes(exists map[string]bool) {
@@ -197,7 +233,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "POST" {
 		r.ParseForm()
 		name := r.Form.Get("repo")
-		err := s.Index(name)
+		index := func() error {
+			commit, err := resolveRevision(s.Root, name, "HEAD")
+			if err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			return s.Index(name, commit)
+		}
+		err := index()
 		if err != nil {
 			data.IndexMsg = fmt.Sprintf("Indexing %s failed: %s", name, err)
 		} else {
@@ -205,9 +248,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.mu.Lock()
-	data.Repos = s.repos
-	s.mu.Unlock()
+	var err error
+	data.Repos, err = listRepos(s.Root)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	repoTmpl.Execute(w, data)
 }

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -69,8 +69,8 @@ func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) error {
 	return nil
 }
 
-// Refresh is starts the sync loop. It blocks forever.
-func (s *Server) Refresh() {
+// Run the sync loop. This blocks forever.
+func (s *Server) Run() {
 	queue := &Queue{}
 
 	// Start a goroutine which updates the queue with commits to index.
@@ -399,5 +399,5 @@ func main() {
 		}()
 	}
 
-	s.Refresh()
+	s.Run()
 }

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -107,24 +107,9 @@ func (s *Server) Run() {
 			sem.Wait()
 			tr.Finish()
 
-			<-t.C
-		}
-	}()
-
-	// Start a goroutine which deletes shards for repos which no longer exist
-	go func() {
-		t := time.NewTicker(s.Interval)
-		for {
-			repos, err := listRepos(s.Root)
-			if err != nil {
-				log.Println(err)
-				<-t.C
-				continue
-			}
-
+			// Only delete shards if we found repositories, to prevent strange
+			// bugs in responses causing us to delete everything.
 			if len(repos) > 0 {
-				// Only delete shards if we found repositories, to prevent strange
-				// bugs in responses causing us to delete everything.
 				exists := make(map[string]bool)
 				for _, name := range repos {
 					exists[name] = true

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -10,8 +10,8 @@ type queueItem struct {
 	repoName string
 	// indexedCommit is the last known indexed commit
 	indexedCommit string
-	// latestCommit is the latest commit available from gitserver. It is the commit
-	// want to index next. It can be the same as current.
+	// latestCommit is the latest commit available from gitserver. It is the
+	// commit want to index next. It can be the same as indexedCommit.
 	latestCommit string
 	// heapIdx is the index of the item in the heap. If < 0 then the item is
 	// not on the heap.

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"container/heap"
+	"sync"
+)
+
+type queueItem struct {
+	// name is the name of the repo
+	name string
+	// indexed is the last known indexed commit
+	indexed string
+	// commit is the latest commit available from gitserver. It is the commit
+	// want to index next. It can be the same as current.
+	commit string
+	// heapIdx is the index of the item in the heap. If < 0 then the item is
+	// not on the heap.
+	heapIdx int
+	// seq is a sequence number used as a tie breaker. This is to ensure we
+	// act like a FIFO queue.
+	seq int64
+}
+
+// Queue is a priority queue which returns the next repo to index. It is safe
+// to use concurrently. It is a min queue on:
+//
+//    (indexed commit != latest commit, time added to the queue)
+//
+// We use the above since:
+//
+// * We rather index a repo sooner if we know the commit is stale.
+// * The order of repos returned by Sourcegraph API are ordered by importance.
+type Queue struct {
+	mu    sync.Mutex
+	items map[string]*queueItem
+	pq    pqueue
+	seq   int64
+}
+
+// Pop returns the name and commit of the next repo to index. If the queue is
+// empty ok is false.
+func (q *Queue) Pop() (name string, commit string, ok bool) {
+	q.mu.Lock()
+	if len(q.pq) == 0 {
+		q.mu.Unlock()
+		return "", "", false
+	}
+	item := heap.Pop(&q.pq).(*queueItem)
+	name = item.name
+	commit = item.commit
+	q.mu.Unlock()
+	return name, commit, true
+}
+
+// Len returns the number of items in the queue.
+func (q *Queue) Len() int {
+	q.mu.Lock()
+	l := len(q.pq)
+	q.mu.Unlock()
+	return l
+}
+
+// AddOrUpdate sets which commit to index next for name. If name is already in
+// the queue, it is updated.
+func (q *Queue) AddOrUpdate(name, commit string) {
+	q.mu.Lock()
+	item := q.get(name)
+	item.commit = commit
+	if item.heapIdx < 0 {
+		q.seq++
+		item.seq = q.seq
+		heap.Push(&q.pq, item)
+	} else {
+		heap.Fix(&q.pq, item.heapIdx)
+	}
+	q.mu.Unlock()
+}
+
+// SetIndexed sets what the currently indexed commit is for name.
+func (q *Queue) SetIndexed(name, indexed string) {
+	q.mu.Lock()
+	item := q.get(name)
+	item.indexed = indexed
+	if item.heapIdx >= 0 {
+		// We only update the position in the queue, never add it.
+		heap.Fix(&q.pq, item.heapIdx)
+	}
+	q.mu.Unlock()
+}
+
+// get returns the item for name. If the name hasn't been seen before, it is
+// added to q.items.
+//
+// Note: get requires that q.mu is held.
+func (q *Queue) get(name string) *queueItem {
+	if q.items == nil {
+		q.items = map[string]*queueItem{}
+		q.pq = make(pqueue, 0)
+	}
+
+	item, ok := q.items[name]
+	if !ok {
+		item = &queueItem{
+			name:    name,
+			heapIdx: -1,
+		}
+		q.items[name] = item
+	}
+
+	return item
+}
+
+// pqueue implements a priority queue via the interface for container/heap
+type pqueue []*queueItem
+
+func (pq pqueue) Len() int { return len(pq) }
+
+func (pq pqueue) Less(i, j int) bool {
+	// If we know a needs an update and b doesn't, then return true. Otherwise
+	// they are either equal priority or b is more urgent.
+	a := pq[i]
+	b := pq[j]
+	if (a.indexed == a.commit) == (b.indexed == b.commit) {
+		// tie breaker is to prefer the item added to the queue first
+		return a.seq < b.seq
+	}
+	return a.indexed != a.commit
+}
+
+func (pq pqueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].heapIdx = i
+	pq[j].heapIdx = j
+}
+
+func (pq *pqueue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*queueItem)
+	item.heapIdx = n
+	*pq = append(*pq, item)
+}
+
+func (pq *pqueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	item.heapIdx = -1
+	*pq = old[0 : n-1]
+	return item
+}

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -118,13 +118,13 @@ func (pq pqueue) Len() int { return len(pq) }
 func (pq pqueue) Less(i, j int) bool {
 	// If we know a needs an update and b doesn't, then return true. Otherwise
 	// they are either equal priority or b is more urgent.
-	a := pq[i]
-	b := pq[j]
-	if (a.indexedCommit == a.latestCommit) == (b.indexedCommit == b.latestCommit) {
+	x := pq[i]
+	y := pq[j]
+	if (x.indexedCommit == x.latestCommit) == (y.indexedCommit == y.latestCommit) {
 		// tie breaker is to prefer the item added to the queue first
-		return a.seq < b.seq
+		return x.seq < y.seq
 	}
-	return a.indexedCommit != a.latestCommit
+	return x.indexedCommit != x.latestCommit
 }
 
 func (pq pqueue) Swap(i, j int) {

--- a/cmd/zoekt-sourcegraph-indexserver/queue_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue_test.go
@@ -7,8 +7,6 @@ import (
 )
 
 func TestQueue(t *testing.T) {
-	// Tests that the queue fallbacks to FIFO if everything has the same
-	// priority
 	queue := &Queue{}
 
 	for i := 0; i < 100; i++ {

--- a/cmd/zoekt-sourcegraph-indexserver/queue_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+func TestQueue(t *testing.T) {
+	// Tests that the queue fallbacks to FIFO if everything has the same
+	// priority
+	queue := &Queue{}
+
+	for i := 0; i < 100; i++ {
+		queue.AddOrUpdate(fmt.Sprintf("item-%d", i), strconv.Itoa(i))
+	}
+
+	// Odd numbers are already at the same commit
+	for i := 1; i < 100; i += 2 {
+		queue.SetIndexed(fmt.Sprintf("item-%d", i), strconv.Itoa(i))
+	}
+
+	// Ensure we process all the even commits first, then odd.
+	want := 0
+	for {
+		name, commit, ok := queue.Pop()
+		if !ok {
+			break
+		}
+		got, _ := strconv.Atoi(commit)
+		if got != want {
+			t.Fatalf("got %v %v, want %v", name, commit, want)
+		}
+		want += 2
+		if want == 100 {
+			// We now switch to processing the odd numbers
+			want = 1
+		}
+		// update current, shouldn't put the job in the queue
+		queue.SetIndexed(name, commit)
+	}
+	if want != 101 {
+		t.Fatalf("only popped %d items", want)
+	}
+}
+
+func TestQueueFIFO(t *testing.T) {
+	// Tests that the queue fallbacks to FIFO if everything has the same
+	// priority
+	queue := &Queue{}
+
+	for i := 0; i < 100; i++ {
+		queue.AddOrUpdate(fmt.Sprintf("item-%d", i), strconv.Itoa(i))
+	}
+
+	want := 0
+	for {
+		name, commit, ok := queue.Pop()
+		if !ok {
+			break
+		}
+		got, _ := strconv.Atoi(commit)
+		if got != want {
+			t.Fatalf("got %v %v, want %v", name, commit, want)
+		}
+		queue.SetIndexed(name, commit)
+		want++
+	}
+	if want != 100 {
+		t.Fatalf("only popped %d items", want)
+	}
+}

--- a/cmd/zoekt-sourcegraph-indexserver/sem.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sem.go
@@ -1,0 +1,28 @@
+package main
+
+import "sync"
+
+type semaphore struct {
+	sema chan bool
+	wg   sync.WaitGroup
+}
+
+func newSemaphore(size int) *semaphore {
+	return &semaphore{
+		sema: make(chan bool, size),
+	}
+}
+
+func (s *semaphore) Acquire() {
+	s.sema <- true
+	s.wg.Add(1)
+}
+
+func (s *semaphore) Release() {
+	<-s.sema
+	s.wg.Done()
+}
+
+func (s *semaphore) Wait() {
+	s.wg.Wait()
+}


### PR DESCRIPTION
This is a major change to how indexserver works, and an increase in complexity.
Our goal is to reduce indexing lag for large installations (10k+ repositories).
In a large installation the majority of repositories will not need updating.
However, the indexer was a simple for loop which checked the latest commit and
then tried to index it incrementally. This meant we spent a large amount of time
doing network requests (to find out the commit) and not any actual processing.

The first change is to introduce a queue which contains (repo, commit). This
allows us to have a dedicated goroutine which just pops jobs off and indexes
them. This ensures we are always busy and not blocked by the Sourcegraph API.

Additionally the queue is a priority queue. This means if we know a repo has a
new commit it can be processed before a repo which has not had any changes. We
still process queue we suspect haven't changed, just in case the underlying data
has gone. This is also good since it means we don't couple how incremental
updates work in zoekt-archive-index with our indexer.

The second change is to concurrently check what the latest commit is for a
repository. Gitserver can handle many concurrent resolve-rev requests, so we
take advantage of that.

Part of https://github.com/sourcegraph/issues-uber/issues/93